### PR TITLE
Update spotter.py 0.6

### DIFF
--- a/spotter.py
+++ b/spotter.py
@@ -17,8 +17,150 @@ ping_wait_timeout = 10  # Time to wait for PING response before joining channel
 
 # Aircraft watchlist criteria with ranges
 watchlist_squawks = ['0001', '0020', '7500', '7700']
-watchlist_aircraft = ['a0001', 'a12345']
-altitude_threshold = 5000
+watchlist_aircraft = [
+    # Elon Musk
+    'a835af',  # Gulfstream G650ER (N628TS) - Elon Musk's primary jet
+    'a2c671',  # Gulfstream G550 (N272BG) - Elon Musk's previous jet
+    'a7c747',  # Gulfstream G650 (N628TS) - Elon Musk (historical)
+
+    # U.S. Presidential Fleet
+    'ae4ae8',  # Boeing VC-25A (92-9000) - Air Force One
+    'ae4ae9',  # Boeing VC-25A (92-8000) - Air Force One
+    'ae01ce',  # Boeing C-32A (99-0003) - Air Force Two
+    'ae01cf',  # Boeing C-32A (99-0004) - Air Force Two
+    'ae4aed',  # C-32B (02-4452)
+    'ae4aee',  # C-32B (00-9001)
+    'ae0402',  # E-4B Nightwatch (73-1676)
+    'ae0410',  # E-6B Mercury (164385)
+    'ae0411',  # E-6B Mercury (164386)
+    'ae0412',  # E-6B Mercury (164387)
+    'ae11f9',  # Boeing E-4B (75-0125) - Doomsday plane
+    'ae11fa',  # Boeing E-4B (74-0787) - Doomsday plane
+
+    # Trump Organization
+    'a72b76',  # Boeing 757 (N757AF) - Trump's personal 757
+    'a9b8f1',  # Cessna Citation X (N725DT) - Trump's Citation
+    'aa3c1f',  # Sikorsky S-76B (N76DT) - Trump's helicopter
+    'a69f59',  # Gulfstream G650ER (N272BG) - Trump backup
+
+    # British Royal Family
+    '43c6f9',  # Airbus A330 Voyager (ZZ336) - RAF VIP transport
+    '43c4ec',  # BAe 146 (ZE700) - Royal Flight
+    '43c4ed',  # BAe 146 (ZE701) - Royal Flight
+
+    # Other Billionaires/Celebrities
+    'a4ff61',  # Boeing 737 (N887WM) - Warren Buffett's NetJets
+    'a9e51e',  # Gulfstream G650 (N721DG) - Mark Cuban
+    'a3f3f6',  # Gulfstream G650ER (N71GE) - Jeff Bezos (rumored)
+    'a5c37c',  # Gulfstream G650 (N464TF) - Taylor Swift (formerly)
+    'a54ac6',  # Global Express (N1F) - Oprah Winfrey
+    'a326ca',  # Gulfstream G650 (N2N) - Laurene Powell Jobs
+    'ac5c30',  # Boeing 767 (N894JB) - Jerry Bruckheimer
+    'a0fc23',  # Gulfstream G650 (N1F) - Nike/Phil Knight
+    'a98682',  # Bombardier Global Express (N660KK) - Kirk Kerkorian estate
+    'aa5ed6',  # Gulfstream G650ER (N825MG) - Michael Jordan
+    'a4f8e0',  # Gulfstream G550 (N887WT) - Oprah Winfrey
+    'a6a378',  # Bombardier Global 6000 (N624AG) - Bill Gates
+    'a0a5c1',  # Gulfstream G650ER (N194WM) - Walmart heirs
+    'a2894f',  # Gulfstream G550 (N271DV) - Google executives
+    'a66aa8',  # Boeing 767 (N606TD) - Tyler Perry
+    'ac7d60',  # Gulfstream G650 (N899JH) - Jay-Z/Beyoncé
+    'a835b0',  # Gulfstream G550 (N628VM) - Jim Carrey
+    'a4b8a2',  # Bombardier Global Express (N884TA) - Tom Cruise
+
+    # Russian Government/Oligarchs
+    '4691c7',  # Airbus A340 (VP-BMS) - Russian government VIP
+    '14f11f',  # Il-96-300PU (RA-96022)
+    '14f100',  # Il-96-300PU (RA-96021)
+    '424070',  # Ilyushin Il-96 (RA-96016) - Putin's primary aircraft
+    '424071',  # Ilyushin Il-96 (RA-96017) - Russian government
+    '43eb2e',  # Airbus A319 (M-KATE) - Alisher Usmanov
+    '4ca83b',  # Boeing 787 (P4-BDL) - Roman Abramovich
+
+    # Other World Leaders
+    '3c6644',  # Airbus A340 (16+01) - German Air Force One
+    '3c6645',  # Airbus A340 (16+02) - German government
+    '3b7ac8',  # Airbus A330 (F-RARF) - French Air Force One
+    '33ffd9',  # Airbus A330 (MM62293) - Italian government
+    '471f49',  # Boeing 737 (LN-KKR) - Norwegian government
+    '440417',  # Airbus A319 (OE-LUX) - Austrian government
+    '4b1a02',  # Airbus A340 (TC-TRK) - Turkish government
+    '71bc08',  # Boeing 747 (HL7643) - South Korean Air Force One
+    '7c4774',  # Boeing 737 (A36-001) - Australian government
+    'e48f76',  # Boeing 777 (FAB2900) - Brazilian Air Force One
+
+    # Special/Unique Aircraft
+    '424242',  # An-225 Mriya (UR-82060) - Destroyed
+    'a0db06',  # Boeing 747 (N748JB) - Virgin Orbit Cosmic Girl
+    'aa3410',  # Boeing 737 (N859WP) - Amazon Prime Air
+    'a4c7e4',  # Boeing 737 (N737AT) - JANET (Area 51)
+    'a4c7e5',  # Boeing 737 (N738AT) - JANET
+    'a6f3a7',  # Boeing 737 (N628TS) - Janet Airlines (Area 51)
+    'a6f3a8',  # Boeing 737 (N365SR) - Janet Airlines
+    'a8df5a',  # Boeing 737 (N869HH) - SpaceX charter
+
+    # NASA Aircraft
+    'ac82ec',  # Boeing 747SP (N747NA) - NASA SOFIA
+    'acd5d4',  # Gulfstream G-III (N992NA) - NASA research
+    'abd8d7',  # WB-57 (N927NA)
+    'acd6cc',  # DC-8 (N817NA)
+    'a547c3',  # Lockheed U-2S (NASA)
+
+    # Antonov An-124s (Antonov Airlines)
+    '508000',  # UR-82007
+    '508101',  # UR-82008
+    '508102',  # UR-82009
+    '508103',  # UR-82029
+    '508104',  # UR-82073
+    '508105',  # UR-82027
+    '508035',  # Antonov An-124 (UR-82072) - Antonov Airlines
+    '508036',  # Antonov An-124 (UR-82073) - Antonov Airlines
+    '50801c',  # Antonov An-124 (UR-82007) - Antonov Airlines
+    '508037',  # Antonov An-124 (UR-82008) - Antonov Airlines
+    '50803a',  # Antonov An-124 (UR-82009) - Antonov Airlines
+
+    # Antonov An-124s (Volga-Dnepr)
+    '15407d',  # RA-82045
+    '15406c',  # RA-82044
+    '15406b',  # RA-82043
+
+    # Antonov An-22
+    '154093',  # RA-09341
+
+   # Ilyushin Il-76
+    '5081a2',  # UR-76744
+    '5081a3',  # UR-78786
+    '145960',  # RA-78830
+    '145961',  # RA-78831
+
+    # C-5M Super Galaxy (USAF)
+    'ae07aa',  # 86-0013
+    'ae07ac',  # 86-0025
+    'ae07ae',  # 87-0036
+
+    # C-17 Globemaster III
+    'ae11f1',  # 01-0187
+    'ae11f2',  # 01-0188
+    '43c26f',  # ZZ176 (RAF)
+    '43c270',  # ZZ177 (RAF)
+
+    # Middle Eastern Royal/Government
+    '710258',  # Boeing 747 (HZ-WBT7) - Saudi Royal Flight
+    '710259',  # Boeing 747 (HZ-HM1B) - Saudi government
+    '896048',  # Boeing 747 (A6-HRM) - Dubai Royal
+    '896049',  # Boeing 747 (A6-PFA) - UAE government
+    '06a1e3',  # Boeing 747 (A9C-HAK) - Bahrain Royal Flight
+    '06a1e4',  # Boeing 747 (A9C-HMK) - Bahrain government
+
+    # Corporate Jets
+    'a494a9',  # Gulfstream G650 (N650GD) - Google executives
+    'a77bd6',  # Boeing 737 (N737ER) - Oracle (Larry Ellison)
+    'a5c657',  # Gulfstream G650 (N502SX) - Starbucks
+    'a154c5',  # Boeing 737 (N227WA) - Walmart corporate
+    'a6dead',  # Gulfstream G650 (N624DG) - Dell corporate
+]
+
+altitude_threshold = 3000
 watchlist_categories = ['A6', 'A7', 'B2', 'B3', 'B4', 'B6', 'B7']
 alert_interval = timedelta(minutes=15)  # 15-minute interval for repeated alerts
 


### PR DESCRIPTION
Aircraft with ICAOs starting with "~" are completely ignored

Aircraft with incomplete data (no squawk, zero altitude, no category, no location) are skipped 

When those incomplete aircraft later appear with valid data, they will trigger alerts since they weren't added to the last_alert_time tracking